### PR TITLE
Add script for building ROM using Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM debian:bullseye-slim@sha256:5cf1d98cd0805951484f33b34c1ab25aac7007bb41c8b9901d97e4be3cf3ab04
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update && \
+    apt-get install \
+        --assume-yes \
+        --no-install-recommends \
+        --quiet=2 \
+	ca-certificates=20210119 \
+        curl=7.74.0-1.3+deb11u3 \
+        make=4.3-4.1 \
+        openjdk-11-jre=11.0.16+8-1~deb11u1 \
+        xz-utils=5.2.5-2.1~deb11u1 && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN curl --silent \
+        --location \
+        --remote-name https://github.com/andwn/marsdev/releases/download/2022.10/mars-2022.10-linux-x64.tar.xz && \
+    echo 'cabe798e396b19a5f3ba46a4b3c75e3fe2176936f8ddc4f9e0a4d3d3de2f5b4b  mars-2022.10-linux-x64.tar.xz' | sha256sum --check && \
+    tar --extract \
+	--file mars-2022.10-linux-x64.tar.xz \
+	--directory "${HOME}"
+
+WORKDIR /src

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 1. Get [marsdev](https://github.com/andwn/marsdev) set up. Vanilla SGDK on Windows may work too, but I didn't try.
 2. Just clone the repo and run `make`.
 
+Alternatively, you can build the ROM using Docker with the command:
+
+    ./build-rom.sh
+
 ### License
 
 Code: MIT

--- a/build-rom.sh
+++ b/build-rom.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+IMAGE_TAG="andwn/ym2020:latest"
+IMAGE_NAME="ym2020"
+GIT_REVISION=$(git rev-parse HEAD)
+
+rm -f ym2020-*.bin
+
+docker build \
+	--tag ${IMAGE_TAG} \
+	.
+
+docker run \
+	--volume "${PWD}:/src" \
+	--rm \
+	--name ${IMAGE_NAME} \
+	${IMAGE_TAG} \
+	/bin/bash -c "make clean all"
+
+mv out.bin "ym2020-${GIT_REVISION}.bin"


### PR DESCRIPTION
This PR adds a simple script for building the ROM using Docker, allowing for reproducible builds.